### PR TITLE
change to SHA256 based on June 15 deadline to drop support for SHA1

### DIFF
--- a/src/com/telesign/util/TeleSignRequest.java
+++ b/src/com/telesign/util/TeleSignRequest.java
@@ -74,7 +74,7 @@ public class TeleSignRequest {
 	private boolean ts_date = false;
 
 	/** An AuthMethod enumeration value  that specifies the strength of the encryption method to use when signing the Authentication header. */
-	private AuthMethod auth = AuthMethod.SHA1;
+	private AuthMethod auth = AuthMethod.SHA256;
 
 	/** Setting default Integer value that specifies the HttpConnection connect timeout value. Having default value as 30000 **/
     private int connectTimeout = 30000;


### PR DESCRIPTION
I think this need to be changed for based on this ?

>  Dear TeleSign Customers and Partners:
> 
> This is a final reminder of scheduled security changes TeleSign originally communicated out on February 2016. 
> 
> As of tomorrow, June 15, 2016, TeleSign will be deprecating the following security components:
> 
> TLS 1.0 Protocol
> TeleSign previously communicated the retirement of TLS 1.0 protocol, scheduled for the second half of 2015 and action was required to maintain connectivity.  This deadline has been extended to June 15, 2016 to provide customers with additional time to make this update. After tomorrow, TeleSign will only support TLS versions 1.1 and 1.2. 
> 
> Once you have made the change, or if you would like to verify that your system is already complying with this requirement, you may send test transactions to https://rbox.telesign.com as this has already been updated with the new security rules.
> 
> SHA-1 Ciphers
> Many of you are probably aware of the potential vulnerabilities of the SHA-1 hash algorithm and the associated retirement plans from the major industry leaders. TeleSign is joining in this industry wide effort by migrating from SHA-1 to higher cryptographic standards.  The following ciphers will be the only ones supported after tomorrow - June 15, 2016 - we ask that you plan accordingly:
> 
> TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
> TLS_RSA_WITH_AES_128_GCM_SHA256
> TLS_RSA_WITH_AES_256_GCM_SHA384
> TLS_RSA_WITH_AES_128_CBC_SHA256 - NEW
> TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 - NEW
> 
> Similar to the above, you can send test transactions to https://rbox.telesign.com to ensure that the changes you’ve made are compliant with the new security standards.    
> 
> We would like to thank you in advance for your cooperation in this matter.  Should you have any questions regarding the above notice, please do not hesitate to contact us at Support@telesign.com. 
> 
> Kind Regards,
> TeleSign Support
