### PR TITLE
Fix application/json support for PhoneID.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+## [2.2.2]((http://central.maven.org/maven2/com/telesign/telesign/2.2.2/) - 2018-05-25
+- 2019-05-20
+  - Fixed support for application/json content-type
+
 ## [2.2.1](http://central.maven.org/maven2/com/telesign/telesign/2.2.1/) - 2018-03-09
 - 2018-03-09
   - Added support for application/json content-type

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'com.telesign'
-version '2.2.1'
+version '2.2.2'
 
 apply plugin: 'idea'
 apply plugin: 'java'

--- a/src/main/java/com/telesign/PhoneIdClient.java
+++ b/src/main/java/com/telesign/PhoneIdClient.java
@@ -4,11 +4,14 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.Proxy;
 import java.security.GeneralSecurityException;
+import java.util.HashMap;
 import java.util.Map;
 
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
-import com.google.gson.Gson;;
+import com.google.gson.Gson;
 
 /**
  * A set of APIs that deliver deep phone number data attributes that help optimize the end user
@@ -49,17 +52,33 @@ public class PhoneIdClient extends RestClient {
      */
     public TelesignResponse phoneid(String phoneNumber, Map<String, ? extends Object> params) throws IOException, GeneralSecurityException {
 
-        return this.post(String.format(PHONEID_RESOURCE, phoneNumber), params);
-   }
-   
-   @Override 
-   public RequestBody createRequestBody(Map<String, ? extends Object> params) throws UnsupportedEncodingException {
-	   String jsonString = (new Gson()).toJson(params);
-	   return params != null ? RequestBody.create(PhoneIdClient.JSON, jsonString.getBytes()) : RequestBody.create(PhoneIdClient.JSON, "");      
-   }
-   
-   @Override
-   protected String getContentType() {
-	   return "application/json";
+        return this.post(String.format(PHONEID_RESOURCE, phoneNumber), params, JSON_CONTENT_TYPE);
+    }
+
+    @Override
+    public RequestBody createRequestBody(Map<String, ? extends Object> params, String contentType) throws UnsupportedEncodingException, IOException {
+        if (contentType.equals(JSON_CONTENT_TYPE)) {
+            Gson gson = new Gson();
+            JsonObject jsonObject = new JsonObject();
+            HashMap<String, Object> paramsCopy = new HashMap<>(params);
+
+            if (paramsCopy.containsKey("addons")) {
+                jsonObject.add("addons", gson.toJsonTree(
+                        paramsCopy.remove("addons"),
+                        new TypeToken<HashMap<String, HashMap<String, String>>>() {
+                        }.getType()));
+            }
+
+            JsonObject paramsObject = gson.toJsonTree(params, new TypeToken<HashMap<String, String>>() {
+            }.getType()).getAsJsonObject();
+            for (String key : paramsCopy.keySet()) {
+                jsonObject.add(key, paramsObject.get(key));
+            }
+
+            String jsonString = jsonObject.toString();
+            return params != null ? RequestBody.create(com.telesign.PhoneIdClient.JSON, jsonString.getBytes()) : RequestBody.create(com.telesign.PhoneIdClient.JSON, "");
+        } else {
+            return super.createRequestBody(params, contentType);
+        }
    }
 }

--- a/src/test/java/com/telesign/JsonCreateRequestBodyTest.java
+++ b/src/test/java/com/telesign/JsonCreateRequestBodyTest.java
@@ -1,0 +1,88 @@
+package com.telesign;
+
+import junit.framework.TestCase;
+import okhttp3.RequestBody;
+import okio.Buffer;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class JsonCreateRequestBodyTest extends TestCase {
+
+    private void makeRequestBodyAndAssert(HashMap<String, ? extends Object> params, String expectedJson) {
+        PhoneIdClient phoneIdClient = new PhoneIdClient("", "");
+        Buffer actualJsonBuffer = new Buffer();
+        try {
+            RequestBody rb = phoneIdClient.createRequestBody(params, RestClient.JSON_CONTENT_TYPE);
+            rb.writeTo(actualJsonBuffer);
+        } catch (IOException exc) {
+            fail(exc.getMessage());
+        }
+        assertEquals(expectedJson, actualJsonBuffer.readUtf8());
+    }
+
+    public void testEmptyParams() {
+        makeRequestBodyAndAssert(new HashMap<String, Object>(), "{}");
+    }
+
+    public void testNoAddonsParams() {
+        HashMap<String, String> params = new HashMap<String, String>() {{
+            put("originating_ip", "127.0.0.1");
+            put("bogus", "param");
+        }};
+        makeRequestBodyAndAssert(params, "{\"bogus\":\"param\",\"originating_ip\":\"127.0.0.1\"}");
+    }
+
+    public void testAddonParamOnly() {
+        HashMap<String, Object> params = new HashMap<String, Object>() {{
+            put("addons", new HashMap<String, Object>() {{
+                put("contact", new HashMap<>());
+                put("contact_plus", new HashMap<String, String>(){{
+                    put("billing_postal_code", "90210");
+                }});
+                put("contact_match", new HashMap<String, String>() {{
+                    put("first_name", "Bob");
+                    put("last_name", "Smith");
+                    put("address", "12345 Some St");
+                    put("city", "Los Angeles");
+                    put("postal_code", "90210");
+                    put("state", "CA");
+                    put("country", "USA");
+                }});
+                put("current_location", new HashMap<>());
+                put("current_location_plus", new HashMap<>());
+                put("device_info", new HashMap<>());
+                put("number_deactivation", new HashMap<>());
+                put("subscriber_status", new HashMap<>());
+            }});
+        }};
+        makeRequestBodyAndAssert(params, "{\"addons\":{\"contact_plus\":{\"billing_postal_code\":\"90210\"},\"device_info\":{},\"current_location_plus\":{},\"contact\":{},\"number_deactivation\":{},\"subscriber_status\":{},\"contact_match\":{\"country\":\"USA\",\"address\":\"12345 Some St\",\"city\":\"Los Angeles\",\"last_name\":\"Smith\",\"state\":\"CA\",\"postal_code\":\"90210\",\"first_name\":\"Bob\"},\"current_location\":{}}}");
+    }
+    public void testAddonAndRegularParams() {
+        HashMap<String, Object> params = new HashMap<String, Object>() {{
+            put("originating_ip", "127.0.0.1");
+            put("account_lifecycle_event", "create");
+            put("addons", new HashMap<String, Object>() {{
+                put("contact", new HashMap<>());
+                put("contact_plus", new HashMap<String, String>(){{
+                    put("billing_postal_code", "90210");
+                }});
+                put("contact_match", new HashMap<String, String>() {{
+                    put("first_name", "Bob");
+                    put("last_name", "Smith");
+                    put("address", "12345 Some St");
+                    put("city", "Los Angeles");
+                    put("postal_code", "90210");
+                    put("state", "CA");
+                    put("country", "USA");
+                }});
+                put("current_location", new HashMap<>());
+                put("current_location_plus", new HashMap<>());
+                put("device_info", new HashMap<>());
+                put("number_deactivation", new HashMap<>());
+                put("subscriber_status", new HashMap<>());
+            }});
+        }};
+        makeRequestBodyAndAssert(params, "{\"addons\":{\"contact_plus\":{\"billing_postal_code\":\"90210\"},\"device_info\":{},\"current_location_plus\":{},\"contact\":{},\"number_deactivation\":{},\"subscriber_status\":{},\"contact_match\":{\"country\":\"USA\",\"address\":\"12345 Some St\",\"city\":\"Los Angeles\",\"last_name\":\"Smith\",\"state\":\"CA\",\"postal_code\":\"90210\",\"first_name\":\"Bob\"},\"current_location\":{}},\"originating_ip\":\"127.0.0.1\",\"account_lifecycle_event\":\"create\"}");
+    }
+}

--- a/src/test/java/com/telesign/JsonCreateRequestBodyTest.java
+++ b/src/test/java/com/telesign/JsonCreateRequestBodyTest.java
@@ -1,28 +1,38 @@
 package com.telesign;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.reflect.TypeToken;
 import junit.framework.TestCase;
 import okhttp3.RequestBody;
 import okio.Buffer;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 
 public class JsonCreateRequestBodyTest extends TestCase {
 
-    private void makeRequestBodyAndAssert(HashMap<String, ? extends Object> params, String expectedJson) {
+    private void makeRequestBodyAndAssert(HashMap<String, ? extends Object> params) {
         PhoneIdClient phoneIdClient = new PhoneIdClient("", "");
         Buffer actualJsonBuffer = new Buffer();
+        Gson gson = new Gson();
+
         try {
             RequestBody rb = phoneIdClient.createRequestBody(params, RestClient.JSON_CONTENT_TYPE);
             rb.writeTo(actualJsonBuffer);
         } catch (IOException exc) {
             fail(exc.getMessage());
         }
-        assertEquals(expectedJson, actualJsonBuffer.readUtf8());
+        HashMap<String, Object> unserializedJson = gson.fromJson(actualJsonBuffer.readUtf8(),
+                new TypeToken<HashMap<String, Object>>() {}.getType());
+        assertEquals(params, unserializedJson);
     }
 
     public void testEmptyParams() {
-        makeRequestBodyAndAssert(new HashMap<String, Object>(), "{}");
+        makeRequestBodyAndAssert(new HashMap<String, Object>());
     }
 
     public void testNoAddonsParams() {
@@ -30,7 +40,7 @@ public class JsonCreateRequestBodyTest extends TestCase {
             put("originating_ip", "127.0.0.1");
             put("bogus", "param");
         }};
-        makeRequestBodyAndAssert(params, "{\"bogus\":\"param\",\"originating_ip\":\"127.0.0.1\"}");
+        makeRequestBodyAndAssert(params);
     }
 
     public void testAddonParamOnly() {
@@ -56,7 +66,7 @@ public class JsonCreateRequestBodyTest extends TestCase {
                 put("subscriber_status", new HashMap<>());
             }});
         }};
-        makeRequestBodyAndAssert(params, "{\"addons\":{\"contact_plus\":{\"billing_postal_code\":\"90210\"},\"device_info\":{},\"current_location_plus\":{},\"contact\":{},\"number_deactivation\":{},\"subscriber_status\":{},\"contact_match\":{\"country\":\"USA\",\"address\":\"12345 Some St\",\"city\":\"Los Angeles\",\"last_name\":\"Smith\",\"state\":\"CA\",\"postal_code\":\"90210\",\"first_name\":\"Bob\"},\"current_location\":{}}}");
+        makeRequestBodyAndAssert(params);
     }
     public void testAddonAndRegularParams() {
         HashMap<String, Object> params = new HashMap<String, Object>() {{
@@ -83,6 +93,6 @@ public class JsonCreateRequestBodyTest extends TestCase {
                 put("subscriber_status", new HashMap<>());
             }});
         }};
-        makeRequestBodyAndAssert(params, "{\"addons\":{\"contact_plus\":{\"billing_postal_code\":\"90210\"},\"device_info\":{},\"current_location_plus\":{},\"contact\":{},\"number_deactivation\":{},\"subscriber_status\":{},\"contact_match\":{\"country\":\"USA\",\"address\":\"12345 Some St\",\"city\":\"Los Angeles\",\"last_name\":\"Smith\",\"state\":\"CA\",\"postal_code\":\"90210\",\"first_name\":\"Bob\"},\"current_location\":{}},\"originating_ip\":\"127.0.0.1\",\"account_lifecycle_event\":\"create\"}");
+        makeRequestBodyAndAssert(params);
     }
 }

--- a/src/test/java/com/telesign/PhoneIdClientTest.java
+++ b/src/test/java/com/telesign/PhoneIdClientTest.java
@@ -1,0 +1,97 @@
+package com.telesign;
+
+import junit.framework.TestCase;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
+
+public class PhoneIdClientTest extends TestCase {
+
+    private MockWebServer mockServer;
+
+    private String customerId;
+    private String apiKey;
+
+    private SimpleDateFormat rfc2616 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss 'GMT'");
+
+
+    public void setUp() throws Exception {
+        super.setUp();
+
+        this.customerId = "FFFFFFFF-EEEE-DDDD-1234-AB1234567890";
+        this.apiKey = "EXAMPLE----TE8sTgg45yusumoN6BYsBVkh+yRJ5czgsnCehZaOYldPJdmFh6NeX8kunZ2zU1YWaUw/0wV6xfw==";
+
+        this.mockServer = new MockWebServer();
+        this.mockServer.start();
+    }
+
+    public void tearDown() throws Exception {
+        super.tearDown();
+
+        this.mockServer.shutdown();
+    }
+
+    public void testPhoneIdWithParamsAndAddons() throws Exception {
+
+        HashMap<String, Object> params = new HashMap<String, Object>() {{
+            put("originating_ip", "127.0.0.1");
+            put("account_lifecycle_event", "create");
+            put("addons", new HashMap<String, Object>() {{
+                put("contact", new HashMap<>());
+                put("contact_plus", new HashMap<String, String>() {{
+                    put("billing_postal_code", "90210");
+                }});
+            }});
+        }};
+
+        this.mockServer.enqueue(new MockResponse().setBody("{}"));
+
+        PhoneIdClient client = new PhoneIdClient(this.customerId,
+                this.apiKey,
+                this.mockServer.url("").toString().replaceAll("/$", ""));
+
+        client.phoneid("18005555555", params);
+
+        RecordedRequest request = this.mockServer.takeRequest(1, TimeUnit.SECONDS);
+
+        assertEquals("method is not as expected", "POST", request.getMethod());
+        assertEquals("path is not as expected", "/v1/phoneid/18005555555", request.getPath());
+        assertEquals("body is not as expected", "{\"addons\":{\"contact_plus\":{\"billing_postal_code\":\"90210\"},\"contact\":{}},\"originating_ip\":\"127.0.0.1\",\"account_lifecycle_event\":\"create\"}",
+                request.getBody().readUtf8());
+        assertEquals("Content-Type header is not as expected", "application/json",
+                request.getHeader("Content-Type"));
+        assertEquals("x-ts-auth-method header is not as expected", "HMAC-SHA256",
+                request.getHeader("x-ts-auth-method"));
+    }
+
+    public void testPhoneId() throws Exception {
+
+        HashMap<String, Object> params = new HashMap<String, Object>();
+
+        this.mockServer.enqueue(new MockResponse().setBody("{}"));
+
+        PhoneIdClient client = new PhoneIdClient(this.customerId,
+                this.apiKey,
+                this.mockServer.url("").toString().replaceAll("/$", ""));
+
+        client.phoneid("18005555555", params);
+
+        RecordedRequest request = this.mockServer.takeRequest(1, TimeUnit.SECONDS);
+
+        assertEquals("method is not as expected", "POST", request.getMethod());
+        assertEquals("path is not as expected", "/v1/phoneid/18005555555", request.getPath());
+        assertEquals("body is not as expected", "{}",
+                request.getBody().readUtf8());
+        assertEquals("Content-Type header is not as expected", "application/json",
+                request.getHeader("Content-Type"));
+        assertEquals("x-ts-auth-method header is not as expected", "HMAC-SHA256",
+                request.getHeader("x-ts-auth-method"));
+    }
+
+}
+
+


### PR DESCRIPTION
The gson library doesn't handle nested HashMap objects without intervention. This changes the createRequestBody such that it will serialize the addons parameter separately than add to it all other simple key/value pairs from the params HashMap.